### PR TITLE
feat(ui): Add ingredient images to cabinet with placeholder system

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -4,3 +4,6 @@
 
 expo-env.d.ts
 # @end expo-cli
+
+# API Credentials - Keep sensitive keys out of version control
+config/credentials.ts

--- a/frontend/app/(tabs)/my-ingredients.tsx
+++ b/frontend/app/(tabs)/my-ingredients.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useRef, useEffect } from "react";
 import { View, Text, StyleSheet, TextInput, FlatList, TouchableOpacity, Pressable, Modal } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Colors } from "@/constants/Colors";
 
 // Components
@@ -269,7 +270,7 @@ export default function MyIngredientsScreen() {
         ];
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.tabsRow}>
         <Tab label={`Cabinet (${ownedCount})`}  active={activeTab === "cabinet"}  onPress={() => setActiveTab("cabinet")} />
         <Tab label={`Shopping (${wantedCount})`} active={activeTab === "shopping"} onPress={() => setActiveTab("shopping")} />
@@ -315,14 +316,14 @@ export default function MyIngredientsScreen() {
           </View>
         </View>
       </Modal>
-    </View>
+    </SafeAreaView>
   );
 }
 
 /** ---------- Styles ---------- */
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.dark.background, overflow: "visible" },
-  tabsRow: { flexDirection: "row", paddingHorizontal: 12, paddingTop: 8, paddingBottom: 4, gap: 8 },
+  tabsRow: { flexDirection: "row", paddingHorizontal: 12, paddingTop: 16, paddingBottom: 8, gap: 8 },
 
   header: { paddingTop: 16, paddingHorizontal: 20, paddingBottom: 6 },
   title: { fontSize: 24, fontWeight: "700", color: "#F5F0E1" },

--- a/frontend/components/my-ingredients/CabinetRow.tsx
+++ b/frontend/components/my-ingredients/CabinetRow.tsx
@@ -1,9 +1,10 @@
-import React, { useRef } from "react";
-import { View, Text, Pressable, StyleSheet } from "react-native";
+import React, { useRef, useState, useEffect } from "react";
+import { View, Text, Pressable, StyleSheet, Image, ActivityIndicator } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
+import unsplashService from "@/services/unsplashService";
 
 export type Category = "Spirit" | "Liqueur" | "Mixer" | "Juice" | "Garnish" | "Other";
-export type Ingredient = { id: string; name: string; category: Category; owned: boolean; wanted?: boolean; impactScore?: number };
+export type Ingredient = { id: string; name: string; category: Category; owned: boolean; wanted?: boolean; impactScore?: number; imageUrl?: string };
 
 export default function CabinetRow({
   item,
@@ -17,6 +18,29 @@ export default function CabinetRow({
   onRemoveFromCabinet: (id: string) => void;
 }) {
   const swipeRef = useRef<Swipeable>(null);
+  const [imageUrl, setImageUrl] = useState<string | null>(item.imageUrl || null);
+  const [isLoadingImage, setIsLoadingImage] = useState(false);
+
+  useEffect(() => {
+    if (!imageUrl && !isLoadingImage) {
+      loadImage();
+    }
+  }, []);
+
+  const loadImage = async () => {
+    setIsLoadingImage(true);
+    try {
+      const url = await unsplashService.getIngredientImage(item.name);
+      if (url) {
+        setImageUrl(url);
+      }
+    } catch (error) {
+      console.warn(`Failed to load image for ${item.name}:`, error);
+    } finally {
+      setIsLoadingImage(false);
+    }
+  };
+
   const handleOpen = (direction: "left" | "right") => {
     if (direction === "left") onAddToShopping(item.id);
     else if (direction === "right") onRemoveFromCabinet(item.id);
@@ -44,6 +68,17 @@ export default function CabinetRow({
     >
       <View style={styles.rowWrap}>
         <View style={styles.rowCard}>
+          <View style={styles.imageContainer}>
+            {isLoadingImage ? (
+              <ActivityIndicator size="small" color="#9C9CA3" />
+            ) : imageUrl ? (
+              <Image source={{ uri: imageUrl }} style={styles.ingredientImage} />
+            ) : (
+              <View style={styles.placeholderImage}>
+                <Text style={styles.placeholderText}>{item.name.charAt(0)}</Text>
+              </View>
+            )}
+          </View>
           <View style={styles.rowTextWrap}>
             <Text style={styles.rowTitle} numberOfLines={1}>{item.name}</Text>
             <Text style={styles.rowSub} numberOfLines={1}>{item.category}</Text>
@@ -62,6 +97,20 @@ const styles = StyleSheet.create({
   rowCard: {
     flexDirection: "row", alignItems: "center", paddingVertical: 12, paddingHorizontal: 10,
     backgroundColor: "#141419", borderWidth: 1, borderColor: "#232329", borderRadius: 14, overflow: "visible",
+  },
+  imageContainer: {
+    width: 40, height: 40, marginRight: 12, borderRadius: 8, overflow: "hidden",
+    backgroundColor: "#2A2A30", alignItems: "center", justifyContent: "center",
+  },
+  ingredientImage: {
+    width: "100%", height: "100%", resizeMode: "cover",
+  },
+  placeholderImage: {
+    width: "100%", height: "100%", backgroundColor: "#3A3A40", 
+    alignItems: "center", justifyContent: "center",
+  },
+  placeholderText: {
+    color: "#9C9CA3", fontSize: 16, fontWeight: "600",
   },
   rowTextWrap: { flex: 1, marginRight: 8, overflow: "hidden" },
   rowTitle: { color: "#EDEDED", fontSize: 16, fontWeight: "600" },

--- a/frontend/components/my-ingredients/Tab.tsx
+++ b/frontend/components/my-ingredients/Tab.tsx
@@ -12,7 +12,7 @@ export default function Tab({ label, active, onPress }:{
 }
 
 const s = StyleSheet.create({
-  tab: { flex: 1, paddingVertical: 10, borderRadius: 999, borderWidth: 1, alignItems: "center" },
+  tab: { flex: 1, paddingVertical: 12, paddingHorizontal: 8, borderRadius: 999, borderWidth: 1, alignItems: "center" },
   idle: { backgroundColor: "#121216", borderColor: "#22222A" },
   active: { backgroundColor: "#1C1C22", borderColor: "#3A3A42" },
   text: { color: "#CFCFCF", fontWeight: "600", fontSize: 14 },

--- a/frontend/config/unsplash.ts
+++ b/frontend/config/unsplash.ts
@@ -1,0 +1,9 @@
+import { CREDENTIALS } from './credentials';
+
+// Unsplash API Configuration
+export const UNSPLASH_CONFIG = {
+  API_KEY: CREDENTIALS.UNSPLASH_API_KEY,
+  BASE_URL: 'https://api.unsplash.com',
+  CACHE_DURATION: 24 * 60 * 60 * 1000, // 24 hours in milliseconds
+  MAX_IMAGES_PER_HOUR: 50,
+} as const;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6228,16 +6228,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-file-system": {
-      "version": "18.1.11",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
-      "integrity": "sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-font": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
@@ -6451,6 +6441,16 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-14.2.0.tgz",
       "integrity": "sha512-6S51d8pVlDRDsgGAp8BPpwnxtyKiMWEFdezNz+5jVIyT+ctReW42uxnjRgtsdn5sXaqzhaX+Tzk/CWaKCyC0hw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "18.1.11",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
+      "integrity": "sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/frontend/services/unsplashService.ts
+++ b/frontend/services/unsplashService.ts
@@ -1,0 +1,33 @@
+// Placeholder image service for testing
+// TODO: Replace with actual Unsplash integration when database is ready
+
+class ImageService {
+  // Simple placeholder images for testing
+  private placeholderImages: Record<string, string> = {
+    'vodka': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'gin': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'rum': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'tequila': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'whiskey': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'bourbon': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'scotch': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'brandy': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'cognac': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'vermouth': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'bitters': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'liqueur': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'syrup': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'juice': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'soda': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+    'garnish': 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400&h=400&fit=crop',
+  };
+
+  async getIngredientImage(ingredientName: string): Promise<string | null> {
+    // For now, return a placeholder or null
+    // This prevents API calls during development
+    const key = ingredientName.toLowerCase().split(' ')[0]; // Get first word
+    return this.placeholderImages[key] || null;
+  }
+}
+
+export default new ImageService();


### PR DESCRIPTION
Features:
- Added image display to cabinet ingredient rows
- Created placeholder image service for safe development
- Added loading states and fallback placeholders
- Updated CabinetRow component with image container

Architecture:
- Created config/credentials.ts for API key management (gitignored)
- Created services/unsplashService.ts with placeholder implementation
- Updated Ingredient type to include imageUrl field
- Added proper TypeScript types and error handling

Future Goals:
- Replace placeholder service with real Unsplash API integration
- Add rate limiting and caching for API calls
- Store image URLs in database for persistence
- Implement proper image management system

Safety:
- No API calls during development (prevents rate limiting)
- Teammates can run app freely without hitting Unsplash limits
- Easy migration path to real API integration

This provides the visual foundation for ingredient images while keeping development safe and API-quota friendly.