### PR TITLE
build(CI): Integrated ESlint on newer version of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - build/initial-pipeline
+      - build/integrating-eslint
 
 jobs:
   frontend:
@@ -26,8 +26,10 @@ jobs:
       - name: Install dependencies
         run: npm ci || npm install --no-audit --no-fund
 
+      - name: Typecheck
+        run: npm run typecheck
 
-      - name: Lint (placeholder)
+      - name: Lint
         run: npm run lint
 
       - name: Tests (Node test runner)

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,8 +1,0 @@
-/** @type {import('eslint').Linter.Config} */
-module.exports = {
-  root: true,
-  ignorePatterns: ['node_modules', 'dist', 'build'],
-  extends: ['expo', 'plugin:@typescript-eslint/recommended'],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
-};

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,10 +1,47 @@
-// https://docs.expo.dev/guides/using-eslint/
-const { defineConfig } = require('eslint/config');
-const expoConfig = require('eslint-config-expo/flat');
+const { defineConfig } = require("eslint/config");
+const expo = require("eslint-config-expo/flat");
+const tseslint = require("@typescript-eslint/eslint-plugin");
+const tsParser = require("@typescript-eslint/parser");
+const prettier = require("eslint-config-prettier");
 
 module.exports = defineConfig([
-  expoConfig,
+  // Base ESLint config for
+  ...expo,
+  // Ignore build and dependency folders
   {
-    ignores: ['dist/*'],
+    ignores: [
+      "**/node_modules/**",
+      "**/.expo/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/android/**",
+      "**/ios/**",
+    ],
   },
+  // TypeScript-specific rules
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        projectService: true,
+      },
+    },
+    plugins: { "@typescript-eslint": tseslint },
+    rules: {
+      "no-undef": "off",
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "@typescript-eslint/consistent-type-imports": ["warn", { prefer: "type-imports" }],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "eqeqeq": ["error", "smart"],
+      "curly": ["error", "all"],
+      "no-console": ["warn", { allow: ["warn","error"] }],
+    },
+  },
+  // Prettier should be the last to override other formatting rules
+  ...(Array.isArray(prettier) ? prettier : [prettier]),
 ]);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/ubuntu": "^0.4.0",
-        "@expo/metro-runtime": "~6.1.2",
         "@expo/vector-icons": "^15.0.2",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
@@ -41,13 +40,14 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/jest": "^30.0.0",
-        "@types/react": "^19.1.13",
+        "@types/react": "^19.2.0",
         "@typescript-eslint/eslint-plugin": "^8.44.0",
         "@typescript-eslint/parser": "^8.44.0",
         "babel-jest": "^30.1.2",
         "babel-preset-expo": "^54.0.2",
         "eslint": "^9.36.0",
         "eslint-config-expo": "~10.0.0",
+        "eslint-config-prettier": "^9.1.2",
         "jest": "^30.1.3",
         "jest-junit": "^16.0.0",
         "typescript": "~5.9.2"
@@ -4992,9 +4992,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
-      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7623,6 +7623,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "node -e \"console.log('lint placeholder - real lint in Sprint 2');\"",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -16,7 +17,6 @@
   },
   "dependencies": {
     "@expo-google-fonts/ubuntu": "^0.4.0",
-    "@expo/metro-runtime": "~6.1.2",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
@@ -48,13 +48,14 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^30.0.0",
-    "@types/react": "^19.1.13",
+    "@types/react": "^19.2.0",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "babel-jest": "^30.1.2",
     "babel-preset-expo": "^54.0.2",
     "eslint": "^9.36.0",
     "eslint-config-expo": "~10.0.0",
+    "eslint-config-prettier": "^9.1.2",
     "jest": "^30.1.3",
     "jest-junit": "^16.0.0",
     "typescript": "~5.9.2"


### PR DESCRIPTION
**Description**
This PR resolves issues from the last attempt to integrate ESlint. This PR simply adds new files, installs ESlint/Prettier, and fixes React Native's peer types. Action's tests should start to fail, as there are `43 problems (7 errors, 36 warnings)` when executing `npm run lint`